### PR TITLE
Correct the dimension order of resized image

### DIFF
--- a/models/safecount.py
+++ b/models/safecount.py
@@ -62,7 +62,7 @@ class SAFECount(nn.Module):
         for scale in self.exemplar_scales:
             h_rsz = int(h * scale) // 16 * 16
             w_rsz = int(w * scale) // 16 * 16
-            image_scale = F.interpolate(image, size=(w_rsz, h_rsz), mode="bilinear")
+            image_scale = F.interpolate(image, size=(h_rsz, w_rsz), mode="bilinear")
             scale_h = h_rsz / h
             scale_w = w_rsz / w
             boxes_scale = copy.deepcopy(boxes)


### PR DESCRIPTION
The input image is of shape `[1, c, h, w]`. Therefore, the resized image should follow the same dimension order `[h_rsz, w_rsz]`.